### PR TITLE
Add SSE and streamable-http transport support to MCP server

### DIFF
--- a/ollamadiffuser/cli/main.py
+++ b/ollamadiffuser/cli/main.py
@@ -135,12 +135,20 @@ def doctor():
 
 
 @cli.command(name="mcp")
-def mcp_cmd():
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "sse", "streamable-http"]),
+    default="stdio",
+    help="Transport type (default: stdio)",
+)
+@click.option("--host", default="0.0.0.0", help="Bind address for network transports")
+@click.option("--port", type=int, default=9000, help="Port for network transports")
+def mcp_cmd(transport, host, port):
     """Start the MCP (Model Context Protocol) server for AI assistant integration."""
     try:
         from ..mcp.server import main as mcp_main
 
-        mcp_main()
+        mcp_main(transport=transport, host=host, port=port)
     except ImportError:
         rprint("[red]MCP package not installed. Install with:[/red]")
         rprint("[yellow]  pip install 'ollamadiffuser[mcp]'[/yellow]")

--- a/ollamadiffuser/mcp/server.py
+++ b/ollamadiffuser/mcp/server.py
@@ -166,8 +166,18 @@ def create_mcp_server():
     return mcp_server
 
 
-def main():
-    """Entry point for the MCP server (stdio transport)."""
+def main(
+    transport: str = "stdio",
+    host: str = "0.0.0.0",
+    port: int = 9000,
+):
+    """Entry point for the MCP server.
+
+    Args:
+        transport: Transport type - "stdio", "sse", or "streamable-http".
+        host: Bind address for network transports.
+        port: Port for network transports.
+    """
     if not _ensure_mcp():
         sys.exit(1)
 
@@ -177,7 +187,17 @@ def main():
     )
 
     server = create_mcp_server()
-    server.run(transport="stdio")
+
+    if transport == "stdio":
+        server.run(transport="stdio")
+    elif transport in ("sse", "streamable-http"):
+        import uvicorn
+
+        app = server.sse_app() if transport == "sse" else server.streamable_http_app()
+        uvicorn.run(app, host=host, port=port)
+    else:
+        logger.error(f"Unknown transport: {transport}. Use stdio, sse, or streamable-http.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enable running the MCP server over the network for remote/container deployments. Adds --transport, --host, and --port CLI flags to the mcp command. Uses uvicorn directly for network transports since FastMCP.run() does not accept host/port parameters.